### PR TITLE
Docker install support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.4.5-alpine
+COPY requirements.txt /opt/app/requirements.txt
+WORKDIR /opt/app
+RUN pip install -r requirements.txt
+COPY dagda /opt/app
+COPY ./dockerfiles/run.sh /
+RUN chmod +x /run.sh
+ENTRYPOINT ["/bin/sh","/run.sh"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Finally, each analysis result of a docker image is stored into the same MongoDB 
      * [Installation of MongoDB](#installation-of-mongodb)
    * [Populating the database](#populating-the-database)
      * [Database contents](#database-contents)
+   * [Quick install with Docker](#quick-install-with-docker)
    * [Usage](#usage)
    * [Roadmap](#roadmap)
    * [Bugs and Feedback](#bugs-and-feedback)
@@ -122,6 +123,19 @@ The database is called `vuln_database` and there are 3 collections:
 * cve (Common Vulnerabilities and Exposure items) - source NVD NIST
 * bid (BugTraqs Ids items from `http://www.securityfocus.com/`) - source [bidDB_downloader](https://github.com/eliasgranderubio/bidDB_downloader)
 * exploit_db (Offensive Security - Exploit Database) - source [Offensive Security](https://github.com/offensive-security/exploit-database)
+
+## Quick Install with Docker
+
+This section describes the installation of **Dagda** using Docker containers, including the Mongo database and a container for **Dagda**, using ```docker-compose```. The docker socket is shared with the **Dagda** container, so it is possible to check docker images and containers from the host where ```docker-compose``` is executed.
+
+Execute the following commands in the root folder of **Dagda**:
+
+```
+$ docker-compose build
+$ docker-compose run --rm dagda vuln_db.py --init
+$ docker-compose run --rm dagda check_docker_image.py -c <container_id>
+```
+
 
 ## Usage
 **IMPORTANT NOTE:** In this **Dagda** version, the `docker pull` command must be run out-of-the-box because this functionality is not included. That is way, the docker image must be in the host when you run `check_docker_image`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  vulndb:
+    image: mongo
+    container_name: vulndb
+    ports:
+      - "27017:27017"
+  dagda:
+    build: .
+    container_name: dagda
+    environment:
+      - VULNDB_HOST=vulndb
+    links:
+        - vulndb
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sed -i 's/localhost/'"$VULNDB_HOST"'/g' /opt/app/etc/checker.conf
+python "$@"


### PR DESCRIPTION
Installation of **Dagda** using Docker containers, including the Mongo database (_vulndb_) and a container for **Dagda** (_dagda_), using ```docker-compose```. 

The docker socket is shared with the **Dagda** container, so it is possible to check docker images and containers from the host where ```docker-compose``` is executed.

```
$ docker-compose build
$ docker-compose run --rm dagda vuln_db.py --init
$ docker-compose run --rm dagda check_docker_image.py -c <container_id>
```