### PR TITLE
History endpoint to get every history on every image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ bin/
 
 # NetBeans specific files/directories
 .nbattrs
+
+db/*
+!db/.gitkeep
+

--- a/dagda/api/service/history.py
+++ b/dagda/api/service/history.py
@@ -8,7 +8,15 @@ from api.internal.internal_server import InternalServer
 history_api = Blueprint('history_api', __name__)
 
 
-# Get the init db process status
+# Get the history of an image analysis
+@history_api.route('/v1/history', methods=['GET'])
+def get_history():
+    history = InternalServer.get_mongodb_driver().get_docker_image_all_history()
+    if len(history) == 0:
+        return json.dumps({'err': 404, 'msg': 'Analysis not found'}, sort_keys=True), 404
+    return json.dumps(history, sort_keys=True)
+
+# Get the history of an image analysis
 @history_api.route('/v1/history/<path:image_name>', methods=['GET'])
 def get_history_by_image_name(image_name):
     id = request.args.get('id')


### PR DESCRIPTION
Added a new history endpoint to get information from every history on every image

```GET /v1/history```

Will return something like

```
[
  {
    "anomalies": 0,
    "image_name": "registry",
    "libs_vulns": 0,
    "os_vulns": 3,
    "reportid": "587e5346c0d56f0007f22614",
    "start_date": "2017-01-17 17:25:17.501547",
    "status": "Completed"
  },
  {
    "anomalies": 0,
    "image_name": "mongo",
    "libs_vulns": 0,
    "os_vulns": 9,
    "reportid": "587e523ac0d56f0007f22613",
    "start_date": "2017-01-17 17:21:22.946576",
    "status": "Completed"
  }
]
```

```anomalies```, ```libs_vulns``` and ```os_vulns``` are the number of results found after the anallysis of the image. ```reportid``` is the identifier of the analysis