### PR TITLE
Response with Content-Type = application/json

### DIFF
--- a/dagda/api/dagda_server.py
+++ b/dagda/api/dagda_server.py
@@ -18,9 +18,9 @@
 #
 
 import os
-import json
 import datetime
 from flask import Flask
+from flask import jsonify
 from flask_cors import CORS, cross_origin
 from api.internal.internal_server import InternalServer
 from api.service.check import check_api
@@ -101,17 +101,17 @@ class DagdaServer:
     # 400 Bad Request error handler
     @app.errorhandler(400)
     def bad_request(self):
-        return json.dumps({'err': 400, 'msg': 'Bad Request'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad Request'}), 400
 
     # 404 Not Found error handler
     @app.errorhandler(404)
     def not_found(self):
-        return json.dumps({'err': 404, 'msg': 'Not Found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Not Found'}), 404
 
     # 500 Internal Server error handler
     @app.errorhandler(500)
     def internal_server_error(self):
-        return json.dumps({'err': 500, 'msg': 'Internal Server Error'}, sort_keys=True), 500
+        return jsonify({'err': 500, 'msg': 'Internal Server Error'}), 500
 
     # -- Private methods
 

--- a/dagda/api/service/check.py
+++ b/dagda/api/service/check.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 
-import json
 import datetime
 from flask import Blueprint
+from flask import jsonify
 from exception.dagda_error import DagdaError
 from log.dagda_logger import DagdaLogger
 from api.internal.internal_server import InternalServer
@@ -34,7 +34,7 @@ check_api = Blueprint('check_api', __name__)
 def check_docker_by_image_name(image_name):
     # -- Check input
     if not image_name:
-        return json.dumps({'err': 400, 'msg': 'Bad image name'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad image name'}), 400
 
     # -- Docker pull from remote registry if it is necessary
     try:
@@ -47,7 +47,7 @@ def check_docker_by_image_name(image_name):
                 raise DagdaError(msg)
             pulled = True
     except:
-        return json.dumps({'err': 404, 'msg': 'Image name not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Image name not found'}), 404
 
     # -- Process request
     data = {}
@@ -62,7 +62,7 @@ def check_docker_by_image_name(image_name):
     output = {}
     output['id'] = str(id)
     output['msg'] = 'Accepted the analysis of <' + image_name + '>'
-    return json.dumps(output, sort_keys=True), 202
+    return jsonify(output), 202
 
 
 # Check docker by container id
@@ -70,13 +70,13 @@ def check_docker_by_image_name(image_name):
 def check_docker_by_container_id(container_id):
     # -- Check input
     if not container_id:
-        return json.dumps({'err': 400, 'msg': 'Bad container id'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad container id'}), 400
 
     # -- Retrieves docker image name
     try:
         image_name = InternalServer.get_docker_driver().get_docker_image_name_by_container_id(container_id)
     except:
-        return json.dumps({'err': 404, 'msg': 'Container Id not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Container Id not found'}), 404
 
     # -- Process request
     data = {}
@@ -90,4 +90,4 @@ def check_docker_by_container_id(container_id):
     output = {}
     output['id'] = str(id)
     output['msg'] = 'Accepted the analysis of <' + image_name + '> with id: ' + container_id
-    return json.dumps(output, sort_keys=True), 202
+    return jsonify(output), 202

--- a/dagda/api/service/docker.py
+++ b/dagda/api/service/docker.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 
-import json
 import datetime
 from flask import Blueprint
+from flask import jsonify
 from api.internal.internal_server import InternalServer
 
 # -- Global
@@ -42,7 +42,7 @@ def get_all_docker_images():
         i['created'] = str(datetime.datetime.utcfromtimestamp(image['Created']))
         i['size'] = sizeof_fmt(image['VirtualSize'])
         output.append(i)
-    return json.dumps(output, sort_keys=True)
+    return jsonify(output)
 
 
 # Gets all running containers info
@@ -58,7 +58,7 @@ def get_all_running_containers():
         c['status'] = container['State']
         c['name'] = container['Names'][0][1:]
         output.append(c)
-    return json.dumps(output, sort_keys=True)
+    return jsonify(output)
 
 
 # -- Util methods

--- a/dagda/api/service/history.py
+++ b/dagda/api/service/history.py
@@ -20,6 +20,7 @@
 import json
 from flask import Blueprint
 from flask import request
+from flask import jsonify
 from api.internal.internal_server import InternalServer
 
 # -- Global
@@ -32,8 +33,8 @@ history_api = Blueprint('history_api', __name__)
 def get_history():
     history = InternalServer.get_mongodb_driver().get_docker_image_all_history()
     if len(history) == 0:
-        return json.dumps({'err': 404, 'msg': 'Analysis not found'}, sort_keys=True), 404
-    return json.dumps(history, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'Analysis not found'}), 404
+    return jsonify(history)
 
 
 # Get the history of an image analysis
@@ -42,8 +43,8 @@ def get_history_by_image_name(image_name):
     id = request.args.get('id')
     history = InternalServer.get_mongodb_driver().get_docker_image_history(image_name, id)
     if len(history) == 0:
-        return json.dumps({'err': 404, 'msg': 'History not found'}, sort_keys=True), 404
-    return json.dumps(history, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'History not found'}), 404
+    return jsonify(history)
 
 
 # Add a new image analysis to the history
@@ -55,7 +56,7 @@ def post_image_analysis_to_the_history(image_name):
     output = {}
     output['id'] = str(id)
     output['image_name'] = image_name
-    return json.dumps(output, sort_keys=True), 201
+    return jsonify(output)
 
 
 # Partial update of image analysis for setting the product vulnerability as false positive
@@ -66,7 +67,7 @@ def set_product_vulnerability_as_false_positive(image_name, product, version=Non
                                                                                      product=product,
                                                                                      version=version)
     if not updated:
-        return json.dumps({'err': 404, 'msg': 'Product vulnerability not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Product vulnerability not found'}), 404
     return '', 204
 
 
@@ -76,5 +77,5 @@ def set_product_vulnerability_as_false_positive(image_name, product, version=Non
 def is_product_vulnerability_a_false_positive(image_name, product, version=None):
     is_fp = InternalServer.get_mongodb_driver().is_fp(image_name=image_name, product=product, version=version)
     if not is_fp:
-        return json.dumps({'err': 404, 'msg': 'Product vulnerability not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Product vulnerability not found'}), 404
     return '', 204

--- a/dagda/api/service/monitor.py
+++ b/dagda/api/service/monitor.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 
-import json
 import datetime
 from flask import Blueprint
+from flask import jsonify
 from api.internal.internal_server import InternalServer
 
 
@@ -33,22 +33,21 @@ monitor_api = Blueprint('monitor_api', __name__)
 def start_monitor_by_container_id(container_id):
     # -- Check runtime monitor status
     if not InternalServer.is_runtime_analysis_enabled():
-        return json.dumps({'err': 503, 'msg': 'Behaviour analysis service unavailable'}, sort_keys=True), 503
+        return jsonify({'err': 503, 'msg': 'Behaviour analysis service unavailable'}), 503
 
     # -- Checks input
     if not container_id:
-        return json.dumps({'err': 400, 'msg': 'Bad container id'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad container id'}), 400
 
     # -- Retrieves docker image name
     try:
         image_name = InternalServer.get_docker_driver().get_docker_image_name_by_container_id(container_id)
     except:
-        return json.dumps({'err': 404, 'msg': 'Container Id not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Container Id not found'}), 404
 
     # -- Checks if the container is already being monitoring
     if InternalServer.get_mongodb_driver().is_there_a_started_monitoring(container_id):
-        return json.dumps({'err': 400, 'msg': 'The monitoring for the requested container id is already started'},
-                          sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'The monitoring for the requested container id is already started'}), 400
 
     now = datetime.datetime.now().timestamp()
     # -- Create image_history
@@ -67,7 +66,7 @@ def start_monitor_by_container_id(container_id):
     output['id'] = str(id)
     output['image_name'] = image_name
     output['msg'] = 'Monitoring of docker container with id <' + container_id + '> started'
-    return json.dumps(output, sort_keys=True), 202
+    return jsonify(output), 202
 
 
 # Stop monitor by container id
@@ -75,22 +74,21 @@ def start_monitor_by_container_id(container_id):
 def stop_monitor_by_container_id(container_id):
     # -- Check runtime monitor status
     if not InternalServer.is_runtime_analysis_enabled():
-        return json.dumps({'err': 503, 'msg': 'Behaviour analysis service unavailable'}, sort_keys=True), 503
+        return jsonify({'err': 503, 'msg': 'Behaviour analysis service unavailable'}), 503
 
     # -- Checks input
     if not container_id:
-        return json.dumps({'err': 400, 'msg': 'Bad container id'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad container id'}), 400
 
     # -- Retrieves docker image name
     try:
         image_name = InternalServer.get_docker_driver().get_docker_image_name_by_container_id(container_id)
     except:
-        return json.dumps({'err': 404, 'msg': 'Container Id not found'}, sort_keys=True), 404
+        return jsonify({'err': 404, 'msg': 'Container Id not found'}), 404
 
     # -- Checks if the container is already being monitoring
     if not InternalServer.get_mongodb_driver().is_there_a_started_monitoring(container_id):
-        return json.dumps({'err': 400, 'msg': 'There is not monitoring for the requested container id'},
-                          sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'There is not monitoring for the requested container id'}), 400
 
     now = datetime.datetime.now().timestamp()
     # -- Process request
@@ -104,4 +102,4 @@ def stop_monitor_by_container_id(container_id):
     InternalServer.get_mongodb_driver().update_docker_image_scan_result_to_history(id, monitoring_result)
 
     # -- Return
-    return json.dumps(InternalServer.get_mongodb_driver().get_docker_image_history(image_name, id)[0], sort_keys=True)
+    return jsonify(InternalServer.get_mongodb_driver().get_docker_image_history(image_name, id)[0])

--- a/dagda/api/service/vuln.py
+++ b/dagda/api/service/vuln.py
@@ -17,10 +17,10 @@
 # under the License.
 #
 
-import json
 import re
 import datetime
 from flask import Blueprint
+from flask import jsonify
 from api.internal.internal_server import InternalServer
 
 
@@ -36,7 +36,7 @@ def init_or_update_db():
     # -- Return
     output = {}
     output['msg'] = 'Accepted the init db request'
-    return json.dumps(output, sort_keys=True), 202
+    return jsonify(output), 202
 
 
 # Get the init db process status
@@ -47,7 +47,7 @@ def get_init_or_update_db_status():
         status['timestamp'] = '-'
     else:
         status['timestamp'] = str(datetime.datetime.utcfromtimestamp(status['timestamp']))
-    return json.dumps(status, sort_keys=True)
+    return jsonify(status)
 
 
 # Gets CVEs, BIDs and Exploit_DB Ids by product and version
@@ -56,8 +56,8 @@ def get_init_or_update_db_status():
 def get_vulns_by_product_and_version(product, version=None):
     vulns = InternalServer.get_mongodb_driver().get_vulnerabilities(product, version)
     if len(vulns) == 0:
-        return json.dumps({'err': 404, 'msg': 'Vulnerabilities not found'}, sort_keys=True), 404
-    return json.dumps(vulns, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'Vulnerabilities not found'}), 404
+    return jsonify(vulns)
 
 
 # Gets products by CVE
@@ -103,14 +103,14 @@ def _execute_cve_query(cve_id, details):
     regex = r"(CVE-[0-9]{4}-[0-9]{4,5})"
     search_obj = re.search(regex, cve_id)
     if not search_obj or len(search_obj.group(0)) != len(cve_id):
-        return json.dumps({'err': 400, 'msg': 'Bad cve format'}, sort_keys=True), 400
+        return jsonify({'err': 400, 'msg': 'Bad cve format'}), 400
     if not details:
         result = InternalServer.get_mongodb_driver().get_products_by_cve(cve_id)
     else:
         result = InternalServer.get_mongodb_driver().get_cve_info_by_cve_id(cve_id)
     if len(result) == 0:
-        return json.dumps({'err': 404, 'msg': 'CVE not found'}, sort_keys=True), 404
-    return json.dumps(result, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'CVE not found'}), 404
+    return jsonify(result)
 
 
 # Executes BID query
@@ -120,8 +120,8 @@ def _execute_bid_query(bid_id, details):
     else:
         result = InternalServer.get_mongodb_driver().get_bid_info_by_id(bid_id)
     if len(result) == 0:
-        return json.dumps({'err': 404, 'msg': 'BugTraq Id not found'}, sort_keys=True), 404
-    return json.dumps(result, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'BugTraq Id not found'}), 404
+    return jsonify(result)
 
 
 # Executes Exploit DB query
@@ -131,5 +131,5 @@ def _execute_exploit_query(exploit_id, details):
     else:
         result = InternalServer.get_mongodb_driver().get_exploit_info_by_id(exploit_id)
     if len(result) == 0:
-        return json.dumps({'err': 404, 'msg': 'Exploit Id not found'}, sort_keys=True), 404
-    return json.dumps(result, sort_keys=True)
+        return jsonify({'err': 404, 'msg': 'Exploit Id not found'}), 404
+    return jsonify(result)


### PR DESCRIPTION
Changed json.dumps to Flask's jsonify to reply with the correct Content-Type: application/json. This is important, for example, to Javascript Frameworks that consumes Dagda API or to see a pretty JSON in Postman and web browsers 

sort_keys is not necessary because jsonify order the keys by default.

:)