### PR TITLE
Update docker-compose so /tmp folder is not ro

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "5000:5000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /tmp:/tmp:ro
+      - /tmp:/tmp
     depends_on:
       - vulndb
   vulndb:


### PR DESCRIPTION
## Status
**TESTING**

## Description
This is needed so 4depcheck is able to work with report files when dagda is running already in a container