### PR TITLE
Add missing dagda envs to compose yml and expand readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,16 @@ Execute the following commands in the root folder of **Dagda** and then, the **D
     docker-compose up -d
 ```
 
+Once the containers are up (`docker ps`) you can continue to use Dagda as before.
+```bash
+docker exec -it dagda python3 dagda.py vuln --init
+docker exec -it dagda python3 dagda.py vuln --init_status
+docker exec -it dagda python3 dagda.py check --docker_image jboss/wildfly  
+docker exec -it dagda python3 dagda.py history jboss/wildfly --id <your-id-here>
+```
+
+You can also check local images using Dagda that you have built `docker exec -it dagda python3 dagda.py check --docker_image alpine:latest` you can also check images that are in a repository such as Amazon's Elastic Container Registry (ECR) `docker exec -it dagda python3 dagda.py check --docker_image 123456789101.dkr.ecr.us-east-1.amazonaws.com/alpine:latest`.
+
 ## Internal workflows
 
 Below, a 10,000 foot diagram about the **Dagda** internal workflows is shown:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build: .
     image: 3grander/dagda:0.8.0
     container_name: dagda
+    environment:
+      - DAGDA_HOST=0.0.0.0
+      - DAGDA_PORT=5000
     networks:
       - mdb
     entrypoint: python dagda.py start -s 0.0.0.0 -p 5000 -m vulndb -mp 27017


### PR DESCRIPTION
## Status
**READY**

## Description
Using docker-compose and interacting with Dagda (on Ubuntu at least) used to error out due to ENV variables not being set. These set it in the docker-compose YAML spec so there are no issues. Also added example commands for interacting with dagda using docker exec

## Related PRs
N/A


## TO-DOs
- [x] Tests
- [x] Documentation


## Deploy Notes
Will just need to restart docker-compose on the host machine after pulling the latest from mainline

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Docker-compose