### PR TITLE
Bump python from 3.8.11 to 3.8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.11-alpine3.14
+FROM python:3.8.12-alpine3.14
 COPY requirements.txt /opt/app/requirements.txt
 WORKDIR /opt/app
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Signed-off-by: daniel sutton <daniel@ducksecops.uk>

## Status
READY

## Description
Upgrade Python to 3.8.12. Upgrade is a security release https://www.python.org/downloads/release/python-3812/
